### PR TITLE
use signal-handler callbacks

### DIFF
--- a/test/machined.rb
+++ b/test/machined.rb
@@ -35,3 +35,6 @@ force_dl = true
 transfer_id = importd.PullRaw(source, img_name, verify_mode, force_dl).first
 
 loop.run
+
+raise "no image found" unless machined.images.detect { |img| img[:name] == img_name }
+puts "found image"

--- a/test/machined.rb
+++ b/test/machined.rb
@@ -11,66 +11,27 @@ require 'dbus/systemd'
 #
 # Importd
 #
-importd_mgr = DBus::Systemd::Importd::Manager.new
-mm = DBus::Systemd::Machined::Manager.new
 
-if  !mm.images.detect { |i| i[:name] == 'Fedora-24' }
-  puts "no image found, checking for transfer in progress"
-  if !importd_mgr.transfers.detect { |i| i[:image_name] == 'Fedora-24' }
-    puts "no transfer found, starting transfer"
-    transfer = importd_mgr.PullRaw('https://dl.fedoraproject.org/pub/fedora/linux/releases/24/CloudImages/x86_64/images/Fedora-Cloud-Base-24-1.2.x86_64.raw.xz', 'Fedora-24', 'no', false)
-    puts "started Fedora-24 import :)"
-    loop do
-      importd_mgr.on_signal('TransferRemoved') do |s|
-        puts s
-        break
-      end
-    end
-  else
-    puts "transfer already in progress"
-   end
-else
-  puts "already downloaded image"
+bus = DBus::Systemd::Helpers.system_bus
+
+importd = DBus::Systemd::Importd::Manager.new(bus)
+machined = DBus::Systemd::Machined::Manager.new(bus)
+
+loop = DBus::Main.new
+loop << bus
+
+transfer_id = nil
+
+importd.on_signal('TransferRemoved') do |id, path, result|
+  puts "Finished transfer: #{id}; Result: #{result}"
+  loop.quit if id == transfer_id
 end
 
-unless importd_mgr.transfers.empty?
-  if importd_mgr.transfers.detect { |t| t[:image_name] == 'Fedora-24' }
-    importd_transfer = DBus::Systemd::Importd::Transfer.new(importd_mgr.map_transfer(transfer)[:id])
-    raise "Bad importd transfer result" unless importd_transfer.properties['Type'] == 'pull-raw'
-    puts "transfer is in progress :)"
-  else
-    puts "no transfer in progress"
-  end
-end
+source = 'https://dl.fedoraproject.org/pub/fedora/linux/releases/24/CloudImages/x86_64/images/Fedora-Cloud-Base-24-1.2.x86_64.raw.xz'
+img_name = 'Fedora-24'
+verify_mode = 'no'
+force_dl = true
 
-#
-# Machined
-#
+transfer_id = importd.PullRaw(source, img_name, verify_mode, force_dl).first
 
-machined_mgr = DBus::Systemd::Machined::Manager.new
-raise "uh oh" unless machined_mgr.respond_to?(:GetMachine)
-puts "successfully checked machined mgr"
-
-if machined_mgr.images.detect { |i| i[:name] == 'Fedora-24' }
-  img = machined_mgr.image('Fedora-24')
-  puts "successfully created image proxy"
-
-  if !machined_mgr.images.detect { |i| i[:name] == 'test' }
-    img.Clone('test', false)
-    puts "successfully cloned image"
-  else
-    puts "already have a test image"
-  end
-
-  if !machined_mgr.machines.detect { |i| i[:name] == 'test' }
-    res = machined_mgr.RegisterMachine('test', '', 'dbus-systemd', 'container', Process.pid, '')
-    raise "register machine failure" unless res.first == '/org/freedesktop/machine1/machine/test'
-    puts "successfully registered machine"
-
-    machine = DBus::Systemd::Machined::Machine.new('test')
-    raise "machine trouble" unless machine.GetOSRelease.first['VERSION_ID'] == '24'
-    puts "successfully checked machine properties"
-  else
-    puts "already have a test machine"
-  end
-end
+loop.run


### PR DESCRIPTION
rewrite the test scripts to use callbacks, simplifies control flow and provides a handy reference.